### PR TITLE
Bump Updatecli version

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,17 +1,14 @@
 name: "Updatecli: Dependency Management"
-
 on:
   schedule:
     # Runs at 06 PM UTC
     - cron: '0 18 * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
 permissions:
   contents: write
   issues: write
   pull-requests: write
-
 jobs:
   updatecli:
     runs-on: ubuntu-latest
@@ -19,19 +16,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
           cache: false
-
       - name: Install Updatecli
         id: updatecli
         uses: updatecli/updatecli-action@v2
         with:
-          version: v0.72.0
-
+          version: v0.84.1
       - name: Delete leftover UpdateCLI branches
         run: |
           gh pr list \
@@ -50,7 +44,6 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Apply Updatecli
         # Never use '--debug' option, because it might leak the access tokens.
         run: "updatecli apply --clean --config ./updatecli/updatecli.d/ --values ./updatecli/values.yaml"

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -27,6 +27,7 @@ jobs:
           cache: false
 
       - name: Install Updatecli
+        id: updatecli
         uses: updatecli/updatecli-action@v2
         with:
           version: v0.72.0


### PR DESCRIPTION



<Actions>
    <action id="cd3b7beedb3e9a8ce8f77a18fb595cdd8654a9094cccbe3891d784c1dc04bb0c">
        <h3>Bump Updatecli version</h3>
        <details id="fb0b23773a1f394e1a57e9e2fdbc97015aad731444bb1dc32ea056a76e918be7">
            <summary>Update Updatecli version in GHA workflow</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.jobs.updatecli.steps[?(@.id == &#39;updatecli&#39;)].with.version&#34; updated from &#34;v0.72.0&#34; to &#34;v0.84.1&#34;, in file &#34;.github/workflows/updatecli.yml&#34;</p>
            <details>
                <summary>v0.84.1</summary>
                <pre>&#xA;Release published on the 2024-09-30 09:44:40 +0000 UTC at the url https://github.com/updatecli/updatecli/releases/tag/v0.84.1&#xA;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;- chore(text): switch to httpclient @loispostula (#2622)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- Fix prerelease semver filtering when current version is stable @gionn (#2736)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(go): bump module github.com/fluxcd/source-controller/api @updateclibot (#2729)&#xD;&#xA;- deps(go): bump module github.com/drone/go-scm @updateclibot (#2724)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 @updateclibot (#2719)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 @updateclibot (#2713)&#xD;&#xA;- deps(go): bump module github.com/drone/go-scm @updateclibot (#2706)&#xD;&#xA;- deps(go): bump module github.com/beevik/etree @updateclibot (#2702)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go @updateclibot (#2691)&#xD;&#xA;- deps(go): bump module github.com/getsops/sops/v3 @updateclibot (#2684)&#xD;&#xA;- deps(go): Bump Golang version to 1.23.1 @updateclibot (#2672)&#xD;&#xA;- deps(go): bump module github.com/testcontainers/testcontainers-go @updateclibot (#2677)&#xD;&#xA;- deps(go): Bump helm &amp; go-containerregistry @olblak (#2671)&#xD;&#xA;- deps(go): bump module golang.org/x/mod @updateclibot (#2669)&#xD;&#xA;- deps(go): bump module golang.org/x/text @updateclibot (#2664)&#xD;&#xA;- deps(go): bump module golang.org/x/oauth2 @updateclibot (#2658)&#xD;&#xA;- chore(deps): Bump github.com/opencontainers/runc from 1.1.12 to 1.1.14 @dependabot (#2647)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@dependabot, @dependabot[bot], @gionn, @loispostula, @olblak, @updateclibot and @updateclibot[bot]&#xD;&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

